### PR TITLE
Add Jon Udell

### DIFF
--- a/data.json
+++ b/data.json
@@ -1904,6 +1904,15 @@
             "hnp": 956
         },
         {
+            "name": "Jon Udell",
+            "url": "https://blog.jonudell.net/",
+            "tags": [
+                "software",
+                "writer"
+            ],
+            "furl": "https://blog.jonudell.net/feed/"
+        },
+        {
             "name": "Jonas Plum",
             "url": "https://blog.cugu.eu/",
             "tags": [

--- a/data.json
+++ b/data.json
@@ -1908,7 +1908,13 @@
             "url": "https://blog.jonudell.net/",
             "tags": [
                 "software",
-                "writer"
+                "thoughts",
+                "science",
+                "internet",
+                "web",
+                "blogging",
+                "database,
+                "technology"
             ],
             "furl": "https://blog.jonudell.net/feed/"
         },


### PR DESCRIPTION
Possibly he should get better tags before merging.

References:
https://en.wikipedia.org/wiki/Jon_Udell

https://jonudell.net/bio.html
> Jon Udell is an author, information architect, software developer, and new media innovator. His 1999 book, Practical Internet Groupware, helped lay the foundation for what we now call social software. He has been a software developer at Lotus; BYTE Magazine's executive editor, feature writer, columnist, and web developer; an independent consultant who helped launch Safari Books Online. 